### PR TITLE
Uglify support

### DIFF
--- a/lib/closure-compiler.rb
+++ b/lib/closure-compiler.rb
@@ -5,6 +5,8 @@ module Closure
   COMPILER_VERSION  = "20110119"
 
   JAVA_COMMAND      = 'java'
+  
+  UGLIFY_PATH       = '~/local/node/bin/uglifyjs'
 
   COMPILER_ROOT     = File.expand_path(File.dirname(__FILE__))
 

--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -9,9 +9,12 @@ module Closure
 
     # When you create a Compiler, pass in the flags and options.
     def initialize(options={})
-      @java     = options.delete(:java)     || JAVA_COMMAND
-      @jar      = options.delete(:jar_file) || COMPILER_JAR
-      @options  = serialize_options(options)
+      @compiler_type = options.delete(:use) || :java
+      
+      @uglify_path   = options.delete(:uglify_path) || UGLIFY_PATH
+      @java          = options.delete(:java)        || JAVA_COMMAND
+      @jar           = options.delete(:jar_file)    || COMPILER_JAR
+      @options       = serialize_options(options)
     end
 
     # Can compile a JavaScript string or open IO object. Returns the compiled
@@ -53,7 +56,15 @@ module Closure
     end
 
     def command
+      (@compiler_type == :java) ? java_command : uglify_command
+    end
+
+    def java_command
       [@java, '-jar', "\"#{@jar}\"", @options].flatten.join(' ')
+    end
+    
+    def uglify_command
+      [@uglify_path, @options].flatten.join(' ')
     end
 
   end


### PR DESCRIPTION
Hey Guys,

I've noticed that with a quick modification to the "command" method, you could easily modify the closure-compiler gem (and hence Jammit) to support UglifyJS (https://github.com/mishoo/UglifyJS).

I've attached a quick hack of this - obviously missing a bunch of stuff. Currently I'm just relying on an installed npm package (the easiest way to get Uglify running imho) but you could obviously include in /vendor in a similar way to the Closure .jar.

In any case, I think this might require some naming changes and follow-on that might be outside the scope of what you are intending (Uglify could easily become a separate gem, although the DRY in me hates the idea of sharing so much code...)

So, just wanting to start a discussion and indicate that I'm ready to follow up with code :)

Cheers,

Nik
