### PR TITLE
allowing multiple --externs options to be passed 

### DIFF
--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -51,7 +51,13 @@ module Closure
 
     # Serialize hash options to the command-line format.
     def serialize_options(options)
-      options.map {|k, v| ["--#{k}", v.to_s] }.flatten
+      options.map do |k, v|
+        if (v.is_a?(Array))
+          v.map {|v2| ["--#{k}", v2.to_s]}
+        else
+          ["--#{k}", v.to_s]
+        end
+      end.flatten
     end
 
     def command

--- a/test/unit/test_closure_compiler.rb
+++ b/test/unit/test_closure_compiler.rb
@@ -60,4 +60,13 @@ class ClosureCompilerTest < Test::Unit::TestCase
     assert File.executable?(COMPILER_JAR)
   end
 
+  def test_serialize_options
+    assert_equal ["--externs",  "library1.js", "--compilation_level", "ADVANCED_OPTIMIZATIONS"], Closure::Compiler.new.send(:serialize_options, 'externs' => 'library1.js', "compilation_level" => "ADVANCED_OPTIMIZATIONS")
+  end
+  
+  def test_serialize_options_for_arrays
+    compiler = Closure::Compiler.new('externs' => ['library1.js', "library2.js"])
+    assert_equal ["--externs", "library1.js", "--externs", "library2.js"], compiler.send(:serialize_options, 'externs' => ['library1.js', "library2.js"])
+  end
+
 end


### PR DESCRIPTION
As initializer takes hash, it was not possible to pass multiple attributes of the same kind. 
I made it possible to pass an array of --extern (or other attributes). See comments of  commit on Github. 
