### PR TITLE
Online service option

### DIFF
--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -1,4 +1,5 @@
 require 'closure/jar'
+require 'closure/online'
 require 'stringio'
 
 module Closure
@@ -10,9 +11,15 @@ module Closure
   # the remote Google's service.
   class Compiler
 
-    # When you create a Compiler, pass in the flags and options.
+    # When you create a Compiler, pass in the flags and options. By default the
+    # local JAR file is used for compilation. Adding `:online => true` to
+    # options makes the Compiler use the online Google's service.
     def initialize(options={})
-      @backend = JAR.new options
+      @backend = if options.delete :online
+                   Online.new options
+                 else
+                   JAR.new options
+                 end
     end
 
     # Can compile a JavaScript string or open IO object. Returns the compiled

--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -1,71 +1,28 @@
+require 'closure/jar'
 require 'stringio'
-require 'tempfile'
 
 module Closure
 
   # We raise a Closure::Error when compilation fails for any reason.
   class Error < StandardError; end
 
-  # The Closure::Compiler is a basic wrapper around the actual JAR. There's not
-  # much to see here.
+  # Compiles a JavaScript string using one of the backends: a local JAR file or
+  # the remote Google's service.
   class Compiler
-    
-    DEFAULT_OPTIONS = {:warning_level => 'QUIET'}
 
     # When you create a Compiler, pass in the flags and options.
     def initialize(options={})
-      @java     = options.delete(:java)     || JAVA_COMMAND
-      @jar      = options.delete(:jar_file) || COMPILER_JAR
-      @options  = serialize_options(DEFAULT_OPTIONS.merge(options))
+      @backend = JAR.new options
     end
 
     # Can compile a JavaScript string or open IO object. Returns the compiled
     # JavaScript as a string or yields an IO object containing the response to a
     # block, for streaming.
     def compile(io)
-      tempfile = Tempfile.new('closure_compiler')
-      if io.respond_to? :read
-        while buffer = io.read(4096) do
-          tempfile.write(buffer)
-        end
-      else
-        tempfile.write(io.to_s)
-      end
-      tempfile.flush
-
-      begin
-        result = `#{command} --js #{tempfile.path}`
-      rescue Exception
-        raise Error, "compression failed"
-      ensure
-        tempfile.close!
-      end
-      unless $?.exitstatus.zero?
-        raise Error, result
-      end
-
+      result = @backend.compile io
       yield(StringIO.new(result)) if block_given?
       result
     end
     alias_method :compress, :compile
-
-
-    private
-
-    # Serialize hash options to the command-line format.
-    def serialize_options(options)
-      options.map do |k, v|
-        if (v.is_a?(Array))
-          v.map {|v2| ["--#{k}", v2.to_s]}
-        else
-          ["--#{k}", v.to_s]
-        end
-      end.flatten
-    end
-
-    def command
-      [@java, '-jar', "\"#{@jar}\"", @options].flatten.join(' ')
-    end
-
   end
 end

--- a/lib/closure/jar.rb
+++ b/lib/closure/jar.rb
@@ -1,0 +1,61 @@
+require 'tempfile'
+
+module Closure
+  # The Closure::JAR is a basic wrapper around the actual JAR. There's not
+  # much to see here.
+  class JAR
+
+    DEFAULT_OPTIONS = {:warning_level => 'QUIET'}
+
+    def initialize(options = {})
+      @java     = options.delete(:java)     || JAVA_COMMAND
+      @jar      = options.delete(:jar_file) || COMPILER_JAR
+      @options  = serialize_options(DEFAULT_OPTIONS.merge(options))
+    end
+
+    # Can compile a JavaScript string or open IO object. Returns the compiled
+    # JavaScript as a string or yields an IO object containing the response to a
+    # block, for streaming.
+    def compile(io)
+      tempfile = Tempfile.new('closure_compiler')
+      if io.respond_to? :read
+        while buffer = io.read(4096) do
+          tempfile.write(buffer)
+        end
+      else
+        tempfile.write(io.to_s)
+      end
+      tempfile.flush
+
+      begin
+        result = `#{command} --js #{tempfile.path}`
+      rescue Exception
+        raise Error, "compression failed"
+      ensure
+        tempfile.close!
+      end
+      unless $?.exitstatus.zero?
+        raise Error, result
+      end
+
+      result
+    end
+
+    private
+
+    # Serialize hash options to the command-line format.
+    def serialize_options(options)
+      options.map do |k, v|
+        if (v.is_a?(Array))
+          v.map {|v2| ["--#{k}", v2.to_s]}
+        else
+          ["--#{k}", v.to_s]
+        end
+      end.flatten
+    end
+
+    def command
+      [@java, '-jar', "\"#{@jar}\"", @options].flatten.join(' ')
+    end
+  end
+end

--- a/lib/closure/online.rb
+++ b/lib/closure/online.rb
@@ -1,0 +1,71 @@
+require 'net/http'
+require 'uri'
+
+module Closure
+
+  # Compiles JavaScript strings using Google's online Closure Compiler service.
+  # See http://code.google.com/intl/pl-PL/closure/compiler/docs/api-ref.html for
+  # a detailed API documentation.
+  class Online
+
+    DEFAULT_OPTIONS = { :compilation_level => :SIMPLE_OPTIMIZATIONS,
+      :output_format => :text, :output_info => :compiled_code }
+
+    # The endpoint of Google's service to which POST requests will be sent.
+    SEVICE_URI = URI.parse 'http://closure-compiler.appspot.com/compile'
+
+    def initialize(options={})
+      @options = DEFAULT_OPTIONS.merge options
+      load_externs if @options['externs']
+    end
+
+    def compile(io)
+      if io.respond_to? :read
+        code = io.read
+      else
+        code = io
+      end
+
+      begin
+        result = query_the_service code
+      rescue Exception
+        raise Error, "compression failed"
+      end
+
+      result
+    end
+
+    private
+
+    # Sends a POST query to the service. Returns a returned string or raises an
+    # exception in case of any errors.
+    def query_the_service code
+      res = Net::HTTP.post_form SEVICE_URI, @options.merge({:js_code => code})
+      if res.is_a? Net::HTTPSuccess and not is_error? res.body
+        res.body
+      else
+        raise res.body
+      end
+    end
+
+    # Returns true if the body of the response sent by the service is empty, a
+    # single newline or an error message string.
+    #
+    # The Closure Compiler service could provide more information about errors
+    # which prevented sent code from being compiled but in order to get them
+    # we'd have to send another request. Trying to save our quota we won't ask
+    # for more.
+    def is_error? response
+      response.empty? or response == "\n" or response =~ /^Error\(\d+\):/
+    end
+
+    # Loads contents of extern files and puts them in the @options hash.
+    def load_externs
+      extern_code = @options['externs'].reduce '' do |code, filename|
+        code + File.read(filename)
+      end
+      @options['js_externs'] = extern_code
+      @options.delete 'externs'
+    end
+  end
+end

--- a/test/unit/closure_compiler_test.rb
+++ b/test/unit/closure_compiler_test.rb
@@ -64,18 +64,4 @@ class ClosureCompilerTest < Test::Unit::TestCase
     assert File.executable?(COMPILER_JAR)
   end
 
-  def test_serialize_options
-    options = { 'externs' => 'library1.js', "compilation_level" => "ADVANCED_OPTIMIZATIONS" }
-    # ["--externs",  "library1.js", "--compilation_level", "ADVANCED_OPTIMIZATIONS"]
-    # although Hash in 1.8 might change the order to : 
-    # ["--compilation_level", "ADVANCED_OPTIMIZATIONS", "--externs",  "library1.js"]
-    expected_options = options.to_a.map { |arr| [ "--#{arr[0]}", arr[1] ] }.flatten
-    assert_equal expected_options, Closure::Compiler.new.send(:serialize_options, options)
-  end
-  
-  def test_serialize_options_for_arrays
-    compiler = Closure::Compiler.new('externs' => ['library1.js', "library2.js"])
-    assert_equal ["--externs", "library1.js", "--externs", "library2.js"], compiler.send(:serialize_options, 'externs' => ['library1.js', "library2.js"])
-  end
-
 end


### PR DESCRIPTION
This is a follow-up to the [pull request #14](https://github.com/documentcloud/closure-compiler/pull/14).

The `Closure::Compiler` class became a thin layer which decides which backend to run depending on ctor's arguments. If `:option => true` is passed then the online Google's service is used for compilation. The default behaviour wasn't changed.