### PR TITLE
Use ECMAScript 5 by default

### DIFF
--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -9,8 +9,11 @@ module Closure
   # The Closure::Compiler is a basic wrapper around the actual JAR. There's not
   # much to see here.
   class Compiler
-
-    DEFAULT_OPTIONS = {:warning_level => 'QUIET'}
+    
+    DEFAULT_OPTIONS = {
+      :warning_level => 'QUIET',
+      :language_in => 'ECMASCRIPT5'
+    }
 
     # When you create a Compiler, pass in the flags and options.
     def initialize(options={})


### PR DESCRIPTION
All modern browsers use ES5 as their standard, and it often causes confusion when Javascript files fail to compress, but work in the browser.  I often run into this roadblock when using the Rails Asset Pipeline in development mode (no compression) vs precompiling (with compression). 

This change makes ES5 the default compression.
