### PR TITLE
Run the compiler in-process on JRuby

### DIFF
--- a/lib/closure-compiler.rb
+++ b/lib/closure-compiler.rb
@@ -13,3 +13,4 @@ module Closure
 end
 
 require 'closure/compiler'
+require 'closure/jruby_runner' if defined?(JRUBY_VERSION)

--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -52,14 +52,19 @@ module Closure
     def compile_files(files)
       @options.merge!({js: files})
 
-      begin
-        result = `#{command} 2>&1`
-      rescue Exception
-        raise Error, "compression failed: #{result}"
-      end
+      if defined?(JRUBY_VERSION)
+        args = serialize_options(@options)
+        result = JRubyRunner.run(args)
+      else
+        begin
+          result = `#{command} 2>&1`
+        rescue Exception
+          raise Error, "compression failed: #{result}"
+        end
 
-      unless $?.exitstatus.zero?
-        raise Error, result
+        unless $?.exitstatus.zero?
+          raise Error, result
+        end
       end
 
       yield(StringIO.new(result)) if block_given?

--- a/lib/closure/jruby_runner.rb
+++ b/lib/closure/jruby_runner.rb
@@ -1,0 +1,32 @@
+require 'java'
+module Closure
+  require COMPILER_JAR
+  class JRubyRunner < com.google.javascript.jscomp.CommandLineRunner
+    def self.run(args)
+      output_contents = java.io.ByteArrayOutputStream.new
+      output = java.io.PrintStream.new(output_contents)
+      error_contents = java.io.ByteArrayOutputStream.new
+      error = java.io.PrintStream.new(error_contents)
+      runner = JRubyRunner.new(args.to_java(:String), output, error)
+      runner.do_run
+      if !error_contents.to_s.empty?
+        raise Error, "compression failed: #{error_contents.to_s}"
+      end
+      output_contents.to_s
+    ensure
+      output.close
+      error.close
+    end
+
+    def createCompiler
+      compiler = com.google.javascript.jscomp.Compiler.new(getErrorPrintStream())
+      # It would be nice to leave threads enabled but if we do then
+      # any process using this must wait at least 60 seconds after
+      # using closure-compiler before the process will exit, due to
+      # the underlying JVM thread pool keeping threads alive until
+      # they time out, which is 60 seconds.
+      compiler.disable_threads
+      compiler
+    end
+  end
+end


### PR DESCRIPTION
The closure compiler runs significantly faster under JRuby when run
in-process versus shelling out. Behavior on non-JRuby runtimes remains
unchanged.

This was tested under JRuby 1.7.1 and Ruby 1.9.3 and passes all tests in both.
