### PR TITLE
Use 1.8 hash syntax 

### DIFF
--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -50,7 +50,7 @@ module Closure
     # resulting JavaScript as a string or yields an IO object containing the
     # response to a block, for streaming.
     def compile_files(files)
-      @options.merge!({js: files})
+      @options.merge!(:js => files)
 
       begin
         result = `#{command} 2>&1`


### PR DESCRIPTION
This commit broke 1.8 support:

https://github.com/documentcloud/closure-compiler/commit/ec898c938ccb9f4bdb77b0c68a7db14670230116#L0R53
