### PR TITLE
expose #options attribute

### DIFF
--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -9,6 +9,8 @@ module Closure
   # The Closure::Compiler is a basic wrapper around the actual JAR. There's not
   # much to see here.
   class Compiler
+
+    attr_accessor :options
     
     DEFAULT_OPTIONS = {
       :warning_level => 'QUIET',


### PR DESCRIPTION
Motivation: when using Jammit with multiple packages, it is useful to vary options given to the jar based on an individual package.

For example, to generate source maps the closure compiler takes an option `--create_source_map`, with the path for the output source map. If I have 3 packages in my Jammit assets.yml, the last one to be packaged will overwrite the source map file (as the 2nd one will have already done to the 1st).

(actually getting Jammit to do this correctly will require some changes in that project; a pull request there is forthcoming)

This patch allows the options hash to be changed for each run, without creating a new `Closure::Compiler` object. Creating a new object is feasible too, although a bit less clean imo.
