### PR TITLE
Fix whitespace issue for paths to compiler

### DIFF
--- a/lib/closure/compiler.rb
+++ b/lib/closure/compiler.rb
@@ -55,6 +55,11 @@ module Closure
     # resulting JavaScript as a string or yields an IO object containing the
     # response to a block, for streaming.
     def compile_files(files)
+      if (files.is_a?(Array))
+        files = files.map { |file| '"' + file + '"' }
+      else
+        files = '"' + files + '"'
+      end
       @options.merge!(:js => files)
 
       begin


### PR DESCRIPTION
The fix put in for #18 by 8be481b005 was lost, and whitespaces were
an issue again in 1.1.8.
