### PR TITLE
Add license to gemspec

### DIFF
--- a/closure-compiler.gemspec
+++ b/closure-compiler.gemspec
@@ -2,6 +2,7 @@ Gem::Specification.new do |s|
   s.name      = 'closure-compiler'
   s.version   = '1.1.11'            # Keep version in sync with closure-compiler.rb
   s.date      = '2014-07-30'
+  s.license   = 'Apache 2.0'
 
   s.homepage    = "http://github.com/documentcloud/closure-compiler/"
   s.summary     = "Ruby Wrapper for the Google Closure Compiler"


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.