### PR TITLE
Updated compiler jar file to 20151015

### DIFF
--- a/lib/closure-compiler.rb
+++ b/lib/closure-compiler.rb
@@ -2,7 +2,7 @@ module Closure
 
   VERSION           = "1.1.11"
 
-  COMPILER_VERSION  = "20140730"
+  COMPILER_VERSION  = "20151015"
 
   JAVA_COMMAND      = 'java'
 


### PR DESCRIPTION
I noticed when using the closure-compiler gem to compile some ES6 code that it was breaking on the following code:

```javascript
const foo = {
  delete(arg){
    return "foobar";
  }
};
```

The issue seemed to be with the fact that the key was named `delete` and that it's using ES6 object method shorthand. Updating the compiler jar to the latest (20151015) fixed the issue.