### PR TITLE
Fix gemspec require path

### DIFF
--- a/closure-compiler.gemspec
+++ b/closure-compiler.gemspec
@@ -1,4 +1,4 @@
-require 'lib/closure-compiler'
+require File.expand_path('lib/closure-compiler', File.dirname(__FILE__))
 
 Gem::Specification.new do |s|
   s.name      = 'closure-compiler'


### PR DESCRIPTION
Use full path instead of relative since relative require is not supported in gemspec

```
[!] There was an error while loading `closure-compiler.gemspec`: cannot load such file -- lib/closure-compiler
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from /Users/.../.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/closure-compiler-b4d82678931a/closure-compiler.gemspec:1
 #  -------------------------------------------
 >  require 'lib/closure-compiler'
 #
 #  -------------------------------------------
```